### PR TITLE
Add documentation around environment passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ module.exports = function(environment) {
        * @default undefined
        */
       development: false,
+      
+      /**
+       * Pass the environment to Raven.js
+       *
+       * @type {String}
+       * @default undefined
+       */
+      environment: environment,
 
       /**
        * Injects the logging service as this property.


### PR DESCRIPTION
https://github.com/damiencaselli/ember-cli-sentry/commit/0bd3e842ac1c0505c06acca9f5ba876e2f6c79b1 added the ability to pass the `environment` to Raven.js as per https://docs.sentry.io/clients/javascript/config/ but this option doesn't seem to have a default or to be documented in the README
 

An alternative/addition would be to default it to the current ember-cli environment