### PR TITLE
Document `ignoreUrls` on main config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,15 @@ module.exports = function(environment) {
       whitelistUrls: [],
 
       /**
-       * Options to pass directly to Raven.js. Note: whitelistUrls and
+       * Raven.js option.
+       *
+       * @type {Array}
+       * @default []
+       */
+      ignoreUrls: [],
+
+      /**
+       * Options to pass directly to Raven.js. Note: whitelistUrls, ignoreUrls and
        * includePaths in this will take precedence
        * over the above.
        *


### PR DESCRIPTION
A follow up PR to #87, this PR updates the README to describe configuring `ignoreUrls` in the main config POJO.