### PR TITLE
Pass extra data via captureException/captureMessage

### DIFF
--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -212,7 +212,7 @@ export default Service.extend({
 
           extraParamsContext.extra = assign(this.extraParams.extra, extraParamsContext.extra);
 
-          this.captureException(reason, extraParams);
+          this.captureException(reason, extraParamsContext);
           this.didCaptureException(reason);
         } else {
           let extraParamsContext = {

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -71,21 +71,6 @@ export default Service.extend({
   extraParams: { extra: {} },
 
   /**
-   * In addition to the structured context that Sentry understands,
-   * you can send arbitrary object with key/value pairs of data which 
-   * will be stored alongside the event
-   * 
-   * Example: { "character_name": "Mighty Fighter" }
-   * 
-   * @property extraParams
-   * @type Object
-   * @private
-   */
-  setExtraParams(value) {
-    this.set('extraParams', { extra: value });
-  },
-
-  /**
    * Utility function used internally to check if Raven object
    * can capture exceptions and messages properly.
    *
@@ -275,6 +260,18 @@ export default Service.extend({
     if (error && error.name === 'TransitionAborted') { return true; }
 
     return this.ignoreError(error);
+  },
+
+  /**
+   * In addition to the structured context that Sentry understands,
+   * you can send arbitrary object with key/value pairs of data which 
+   * will be stored alongside the event
+   * 
+   * @method setExtraParams
+   * @param  {Object} extra Example: { "character_name": "Mighty Fighter" }
+   */
+  setExtraParams(extra) {
+    this.set('extraParams', { extra });
   },
 
   /**

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -164,13 +164,14 @@ export default Service.extend({
    *
    * @method captureMessage
    * @param  {String} message The message to capture
+   * @param  {String} extraParams Extra Params
    * @return {Boolean}
    */
-  captureMessage(message) {
+  captureMessage(message, extraParams) {
     if (this.get('isRavenUsable')) {
       Raven.captureMessage(...arguments);
     } else {
-      console.info(message);
+      console.info(message, extraParams);
     }
     return true;
   },


### PR DESCRIPTION
I am adding extraParams support provided in the Sentry documentation https://docs.sentry.io/enriching-error-data/context/?platform=browser#extra-context

@Turbo87 